### PR TITLE
define base px font size for html for proper inheritance

### DIFF
--- a/trumps/_font-size.scss
+++ b/trumps/_font-size.scss
@@ -35,7 +35,8 @@
 }
 
 @mixin font-size-src($display-namespace:"") {
-  html, body { @include font-size(base(font-size), true); }
+  html { font-size: base(font-size); }
+  body { @include font-size(base(font-size), true); }
   h1 { @include font-size(base(h1-size), true); }
   h2 { @include font-size(base(h2-size), true); }
   h3 { @include font-size(base(h3-size), true); }


### PR DESCRIPTION
Recently discovered an odd issue where 1rem isn't equating the base px font size. Realized it was due to `font-size: 1rem` being given to html root document as well as body at the same time.
The root em ends up inheriting the html element's browser default, 16px.
I didn't notice this problem because we had set the base font size to 16px. 
But then I needed to change to 14px and that's when I saw 1rem is = 16px still.

In this PR, I first defined base font-size for `html` cascading down correctly to `body`'s font-size: 1rem. `body` also gets a px base font-size as it should and the two wold equate.
