### PR TITLE
fix flexbox layout on iOS/Safari

### DIFF
--- a/trumps/_flexbox.scss
+++ b/trumps/_flexbox.scss
@@ -16,9 +16,11 @@
       */
     // [container] set flexbox and axes
     &-horizontal, &-vertical {
+      display: -webkit-flex !important;
       display: flex !important;
     }
     &-horizontal-inline, &-vertical-inline {
+      display: -webkit-inline-flex !important;
       display: inline-flex !important;
     }
     &-horizontal {


### PR DESCRIPTION
Add "-webkit-" prefixed display property value fall-backs, as the auto-prefixer seems to be having trouble here.