### PR TITLE
use newer Myth

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "grunt-cli": "~0.1.13",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-contrib-sass": "^0.7.3",
-    "grunt-myth": "~0.1.1",
+    "grunt-myth": "~1.0.0",
     "load-grunt-tasks": "~0.4.0",
     "grunt-shared-config": "~0.3.7",
     "assemble": "~0.4.41",


### PR DESCRIPTION
The previously used version of Myth did not support auto-prefix generation for property values that also had a '!important' declaration.  Bumping the grunt-myth package version (to latest stable) pulls in a version of Myth that does support this prefixing.

Note, this causes the `'dss'` task to busy-wait/hang; I guess this is due to some new markup in the Myth output that DSS (or the `grunt-contrib-dss` package) does not like.